### PR TITLE
Add dayPickerProps for DateInput and DateTimeInput

### DIFF
--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -209,6 +209,7 @@ DateInputForm.args = {
   showIcon: true,
   isDisabled: false,
   format: config.DATE_FORMAT,
+  dayPickerProps: { disabledDays: { before: new Date() } },
   className: "",
   style: {},
   children: (props) => <ControlledDateInput {...props} />,
@@ -253,6 +254,7 @@ DateTimeInputForm.args = {
       );
     },
   },
+  dayPickerProps: { disabledDays: { before: new Date() } },
   isRequired: true,
   showIcon: true,
   isDisabled: false,

--- a/src/Form/FormInputs/DateInput/DateInput.tsx
+++ b/src/Form/FormInputs/DateInput/DateInput.tsx
@@ -4,6 +4,7 @@ import MomentLocaleUtils from "react-day-picker/moment";
 import {
   NavbarElementProps,
   WeekdayElementProps,
+  DayPickerProps,
 } from "react-day-picker/types";
 import classNames from "classnames/bind";
 import FontAwesome from "react-fontawesome";
@@ -74,6 +75,7 @@ export const DateInput: React.FC<DateInputType> = ({
   isValidated = false,
   isError,
   inputRef,
+  dayPickerProps,
 }: DateInputType) => {
   const onDayChange = (value: Date) => {
     const time = getTimeStringFromDate(value, format);
@@ -91,6 +93,7 @@ export const DateInput: React.FC<DateInputType> = ({
           classNames: overlayStyles,
           navbarElement: NavBarElement,
           weekdayElement: WeekDayElement,
+          ...dayPickerProps,
         }}
         onDayPickerHide={onBlur}
         inputProps={{

--- a/src/Form/FormInputs/DateTimeInput/DateTimeInput.tsx
+++ b/src/Form/FormInputs/DateTimeInput/DateTimeInput.tsx
@@ -27,6 +27,7 @@ export const DateTimeInput: React.FC<DateTimeInputType> = ({
   timePlaceholder = "Time",
   use12Hours,
   showSecond,
+  dayPickerProps,
 }: DateTimeInputType) => {
   const sharedProps = {
     name,
@@ -45,6 +46,7 @@ export const DateTimeInput: React.FC<DateTimeInputType> = ({
         inputRef={inputRef}
         format={dateFormat}
         placeholder={datePlaceholder}
+        dayPickerProps={dayPickerProps}
       />
       <TimeInput
         {...sharedProps}

--- a/src/types/Form/FormInputs/DateInput/index.tsx
+++ b/src/types/Form/FormInputs/DateInput/index.tsx
@@ -1,6 +1,6 @@
 import FormInputType from "..";
 import DayPickerInput from "react-day-picker/types/DayPickerInput";
-import { DayModifiers } from "react-day-picker/types";
+import { DayModifiers, DayPickerProps } from "react-day-picker/types";
 import FormInputWrapperType from "../FormInputWrapper";
 
 export type DateInputType = FormInputType & {
@@ -16,6 +16,8 @@ export type DateInputType = FormInputType & {
   onBlur?: () => void | React.FocusEvent;
   /** The moment string format used to show the date in text form */
   format?: string;
+  /** modifiers to adjust dayPicker behaviour */
+  dayPickerProps?: DayPickerProps;
 };
 
 type ControlledDateInputType = DateInputType & FormInputWrapperType;

--- a/src/types/Form/FormInputs/DateTimeInput/index.tsx
+++ b/src/types/Form/FormInputs/DateTimeInput/index.tsx
@@ -1,5 +1,6 @@
 import FormInputType from "..";
 import FormInputWrapperProps from "../FormInputWrapper";
+import { DayPickerProps } from "react-day-picker/types";
 
 export type DateTimeInputType = FormInputType & {
   /** The Date value of the input */
@@ -20,6 +21,8 @@ export type DateTimeInputType = FormInputType & {
   use12Hours?: boolean;
   /** Does the seconds column section in the overlay get shown */
   showSecond?: boolean;
+  /** modifiers to adjust dayPicker behaviour */
+  dayPickerProps?: DayPickerProps;
 };
 
 type ControlledDateTimeInputType = DateTimeInputType & FormInputWrapperProps;

--- a/src/types/Form/FormInputs/FileInput/index.tsx
+++ b/src/types/Form/FormInputs/FileInput/index.tsx
@@ -1,13 +1,12 @@
-import { ReactElement, DragEvent, RefObject } from "react";
+import { DragEvent, RefObject } from "react";
 import FormInputType from "..";
 import FormInputWrapperType from "../FormInputWrapper";
-import { DragAndDropHookType } from "./DragAndDropWrapper";
 
 export type FileInputType = FormInputType & {
   /** The current value of the FileInput */
   value: FileList | null | undefined;
   /** The function called after the input is changed */
-  onChange: (files: FileList | null | undefined) => void;
+  onChange: (files: FileList | File[] | null | undefined) => void;
   /** The function called after the input is blurred */
   onBlur: () => void;
   /** Does the file input accept more than one file or not */

--- a/src/types/Form/FormInputs/TextWithFileInput/index.tsx
+++ b/src/types/Form/FormInputs/TextWithFileInput/index.tsx
@@ -4,7 +4,7 @@ import FormInputWrapperType from "../FormInputWrapper";
 
 export type TextWithFileInputValueType = {
   text: string | undefined;
-  files: FileList | null | undefined;
+  files: FileList | File[] | null | undefined;
 };
 
 export type TextWithFileInputType = FormInputType & {


### PR DESCRIPTION
## Scope
- [x] Enhancement: backwards-compatible functionality added
- [ ] Bug-Fix / Patch: backwards-compatible bug fix / revision
- [ ] RFC: request for comments; discussion only

## Context
The DateInputs in 360 had the ability to disable some days using `dayPickerProps` from [react-day-picker](https://react-day-picker.js.org/api/DayPicker).  Add this functionality in the new DateInput / DateTimeInputs.

## Summary of Changes
- Add `dayPickerProps` prop for DateInput and DateTimeInput
- Fix some missing typings for FileInput and TextWithFileInput

![Screen Shot 2021-11-01 at 1 48 25 PM](https://user-images.githubusercontent.com/34279434/139716705-8d332f01-7d3e-4010-bc1b-c7fca81c2c67.png)



## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Pre-Merge Checklist
- [ ] Changelog entry? (Summary in `/changelog/<section>/<issue_number>.md`)
- [ ] Linked to [Jira issue](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) ?
- [ ] Labels tagged?