### PR TITLE
Increase specificity for inputs of type text

### DIFF
--- a/src/Form/FormInputs/TextInput/TextInput.module.scss
+++ b/src/Form/FormInputs/TextInput/TextInput.module.scss
@@ -6,6 +6,7 @@
 }
 
 .input,
+input[type="text"].input,
 input[type="number"].input {
   border: 1px solid var(--colour-background-dark);
   border-radius: 6px;


### PR DESCRIPTION
## Scope
- [ ] Enhancement: backwards-compatible functionality added
- [x] Bug-Fix / Patch: backwards-compatible bug fix / revision
- [ ] RFC: request for comments; discussion only

## Context
bootstrap has some `input` `attribute` selectors that override the styling. Increase the specificity of the `TextInput` styling to overwrite that.

## Summary of Changes
- Add `type="text"` to the selector to minimally increase selector to overwrite bootstrap but still keep it easily styleable.
- below screen shots show both types of TextInput as well as TextArea, so with this all issues related to bootstrap overwriting inputs should be addressed.

| Before | After |
| ------ | ----- |
| ![Screen Shot 2021-11-10 at 10 57 11 AM](https://user-images.githubusercontent.com/34279434/141148535-9e655c19-9193-47c8-8c4c-7ab93470e45d.png)  | ![Screen Shot 2021-11-10 at 10 58 01 AM](https://user-images.githubusercontent.com/34279434/141148588-ab1f137a-52d1-4a85-8c42-cbcb237f59ef.png) |

## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Pre-Merge Checklist
- [ ] Changelog entry? (Summary in `/changelog/<section>/<issue_number>.md`)
- [ ] Linked to [Jira issue](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) ?
- [ ] Labels tagged?