### PR TITLE
Fix Datatable padding

### DIFF
--- a/src/Table/Datatable.scss
+++ b/src/Table/Datatable.scss
@@ -173,11 +173,4 @@
       display: none;
     }
   }
-
-  .clipText {
-    padding-right: 5px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
 }


### PR DESCRIPTION
## Scope
- [ ] Enhancement: backwards-compatible functionality added
- [x] Bug-Fix / Patch: backwards-compatible bug fix / revision
- [ ] RFC: request for comments; discussion only

## Context
Having `.clipText` in the `datatable.scss` here reduces the intended padding between columns from `20px` to `5px`. Remove it so it goes to the intended spacing.

## Summary of Changes
A brief description of the changes included in the PR. (i.e. rationale behind solution for implementation of a new feature, etc.) Before/After screenshots if applicable.

| Before | After |
| ------ | ----- |
| ![Screen Shot 2022-02-08 at 2 22 30 PM](https://user-images.githubusercontent.com/34279434/153066408-69976bcd-f37b-441e-b26e-6f129849d016.png) | ![Screen Shot 2022-02-08 at 3 02 19 PM](https://user-images.githubusercontent.com/34279434/153066448-8b6843e1-4847-42c3-bef8-18f5825f90b1.png) |

## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Pre-Merge Checklist
- [ ] Changelog entry? (Summary in `/changelog/<section>/<issue_number>.md`)
- [ ] Linked to [Jira issue](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) ?
- [ ] Labels tagged?