### PR TITLE
Add hotjar suppress option to datatable fields

### DIFF
--- a/src/Sidebar/Sidebar.tsx
+++ b/src/Sidebar/Sidebar.tsx
@@ -134,7 +134,11 @@ const Sidebar = ({
               invisible: !isSidebarExpanded,
             })}
           >
-            {name && <div className={cx("name")}>{name}</div>}
+            {name && (
+              <div className={cx("name")} data-hj-suppress>
+                {name}
+              </div>
+            )}
 
             {onProfileClick && (
               <div className={cx("profileLabel")} onClick={onProfileClick}>

--- a/src/Table/DatatableGrid.tsx
+++ b/src/Table/DatatableGrid.tsx
@@ -237,6 +237,7 @@ const DatatableGrid = <T,>({
         <div
           className={`clipText datatable__rightPadding ${columnClassName}`}
           style={{ width: `${headers[columnIndex].width}px` }}
+          data-hj-suppress={headers[columnIndex].suppress}
         >
           {cellRenderer
             ? cellRenderer(rowValue, columnKey)

--- a/src/types/Table/Datatable/index.tsx
+++ b/src/types/Table/Datatable/index.tsx
@@ -28,6 +28,8 @@ export type DatatableHeaderType<T> = {
   wrap?: boolean;
   /** The className applied to each cell */
   className?: string;
+  /** Will the cell contents be recordable in hotjar */
+  suppress?: boolean;
 };
 
 export const DatatableSortDirection = ["asc", "desc"] as const;


### PR DESCRIPTION
## Scope
- [ ] Enhancement: backwards-compatible functionality added
- [ ] Bug-Fix / Patch: backwards-compatible bug fix / revision
- [ ] RFC: request for comments; discussion only

## Context
> We want most text, while still suppressing names. The only way to do this is using custom suppression

We have turned on `Suppress all on page text` option for hotjar, but we want to go back to `Suppress location information` (e.g. show text again). This is done by adding `data-hj-suppress` attribute to the current element or an element containing the data [see here](https://help.hotjar.com/hc/en-us/articles/115012439167).

## Summary of Changes
- Add a `suppress` option to datatable header to add `data-hj-suppress` for each cellRenderer
- Add `data-hj-suppress` to the sidebar name


## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Pre-Merge Checklist
- [ ] Changelog entry? (Summary in `/changelog/<section>/<issue_number>.md`)
- [ ] Linked to [Jira issue](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) ?
- [ ] Labels tagged?