### PR TITLE
Add control label

### DIFF
--- a/src/ControlLabel/ControlLabel.module.scss
+++ b/src/ControlLabel/ControlLabel.module.scss
@@ -1,0 +1,11 @@
+@import "../constants/mixins";
+
+.container {
+  > * + * {
+    margin-top: 6px;
+  }
+}
+
+.label {
+  @include fontStyles(body, 14);
+}

--- a/src/ControlLabel/ControlLabel.module.scss
+++ b/src/ControlLabel/ControlLabel.module.scss
@@ -1,11 +1,6 @@
 @import "../constants/mixins";
 
-.container {
-  > * + * {
-    margin-top: 6px;
-  }
-}
-
 .label {
-  @include fontStyles(body, 14);
+  @include fontStyles(body, 14, true);
+  margin-bottom: 6px;
 }

--- a/src/ControlLabel/ControlLabel.stories.js
+++ b/src/ControlLabel/ControlLabel.stories.js
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import Page from "../Page/Page";
+import ControlLabel from "./ControlLabel";
+import { MultiDropdownInputWithSearch } from "..";
+
+const Template = (args) => {
+  const [value, setValue] = useState(undefined);
+
+  return (
+    <Page title="ControlLabel">
+      <ControlLabel {...args}>
+        <MultiDropdownInputWithSearch
+          options={[
+            { name: "Validere Calgary Facility 1", id: 1 },
+            { name: "Validere Houston Facility 2", id: 1 },
+            { name: "Validere Toronto Facility 3", id: 1 },
+          ]}
+          label="Sites"
+          labelKey="name"
+          width={100}
+          onChange={(value) => setValue(value)}
+          value={value}
+        />
+      </ControlLabel>
+    </Page>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: "A label",
+};
+
+export default {
+  title: "ControlLabel",
+  component: ControlLabel,
+  parameters: {
+    componentSubtitle:
+      "A wrapper component that enforces label and spacing for a control not bound to a form",
+  },
+};

--- a/src/ControlLabel/ControlLabel.test.js
+++ b/src/ControlLabel/ControlLabel.test.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import ControlLabel from "./ControlLabel";
+
+describe("ControlLabel tests", () => {
+  it("should render the control with a label", () => {
+    const label = "some label";
+    const control = "some control";
+
+    const { queryByText } = render(
+      <ControlLabel label={label}>
+        <div>{control}</div>
+      </ControlLabel>
+    );
+    expect(queryByText(label)).toBeTruthy();
+
+    expect(queryByText(control)).toBeTruthy();
+  });
+});

--- a/src/ControlLabel/ControlLabel.tsx
+++ b/src/ControlLabel/ControlLabel.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import * as PropTypes from "prop-types";
+import styles from "./ControlLabel.module.scss";
+import classNames from "classnames/bind";
+import ControlLabelType from "../types/ControlLabel";
+
+const cx = classNames.bind(styles);
+
+const ControlLabel = ({
+  label,
+  children,
+  className,
+  style,
+}: ControlLabelType) => {
+  return (
+    <div className={`${cx("container")} ${className ?? ""}`} style={style}>
+      <div className={cx("label")}>{label}</div>
+
+      {children}
+    </div>
+  );
+};
+
+ControlLabel.propTypes = {
+  label: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  className: PropTypes.string,
+  style: PropTypes.object,
+};
+
+export default ControlLabel;

--- a/src/ControlLabel/ControlLabel.tsx
+++ b/src/ControlLabel/ControlLabel.tsx
@@ -13,7 +13,7 @@ const ControlLabel = ({
   style,
 }: ControlLabelType) => {
   return (
-    <div className={`${cx("container")} ${className ?? ""}`} style={style}>
+    <div className={className ?? ""} style={style}>
       <div className={cx("label")}>{label}</div>
 
       {children}

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ import useSidebar from "./Sidebar/useSidebar";
 import useForm from "./utils/hooks/useForm";
 import Tooltip from "./Tooltip/Tooltip";
 import AlertMessage from "./AlertMessage/AlertMessage";
+import ControlLabel from "./ControlLabel/ControlLabel";
 
 export {
   CustomTable,
@@ -69,6 +70,7 @@ export {
   FilterPillbox,
   Tooltip,
   AlertMessage,
+  ControlLabel,
 };
 
 export default {
@@ -105,4 +107,5 @@ export default {
   FilterPillbox,
   Tooltip,
   AlertMessage,
+  ControlLabel,
 };

--- a/src/types/ControlLabel/index.tsx
+++ b/src/types/ControlLabel/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export type ControlLabelType = {
+  /** The className applied to the containing div */
+  label?: React.ReactNode | React.ReactNode[];
+  /** The inline style object applied to the containing div */
+  style?: React.CSSProperties;
+  /** The className applied to containing div */
+  className?: string;
+  /** The control to be displayed */
+  children: React.ReactNode | React.ReactNode[];
+  /** The id associated with the input and htmlFor */
+};
+
+export default ControlLabelType;


### PR DESCRIPTION
## Scope
- [x] Enhancement: backwards-compatible functionality added
- [ ] Bug-Fix / Patch: backwards-compatible bug fix / revision
- [ ] RFC: request for comments; discussion only

## Context
Controls used outside of forms are starting to appear with a common format (i.e. the label 6px above the control). Make a component that enforces that so it doesn't have to be remade again and again.

## Summary of Changes

![2022-03-01 13 47 18](https://user-images.githubusercontent.com/34279434/156230510-f8c82a5e-f857-4f9b-83eb-16246daa5c17.gif)


## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Pre-Merge Checklist
- [ ] Changelog entry? (Summary in `/changelog/<section>/<issue_number>.md`)
- [ ] Linked to [Jira issue](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) ?
- [ ] Labels tagged?