### PR TITLE
Allow single values for MultiDropdownInputWithSearch

### DIFF
--- a/src/MultiDropdownInputWithSearch/MultiDropdownInputWithSearch.tsx
+++ b/src/MultiDropdownInputWithSearch/MultiDropdownInputWithSearch.tsx
@@ -3,6 +3,7 @@ import Select, { createFilter, StylesConfig, GroupBase } from "react-select";
 import { OptionType } from "../types/Form/FormInputs/SelectInput";
 import styles from "../constants/index";
 import filter from "lodash/filter";
+import get from "lodash/get";
 import FontAwesome from "react-fontawesome";
 import classNames from "classnames/bind";
 import cssStyles from "./MultipleDropdownInputWithsearch.module.scss";
@@ -54,10 +55,10 @@ function getOptionsWithLabels(
 ) {
   if (labelKey) {
     return options.map((option: any) => {
-      option.label = customLabelFormat
-        ? customLabelFormat(option[labelKey])
-        : option[labelKey];
-      option.value = option[labelKey];
+      const label = get(option, labelKey);
+
+      option.label = customLabelFormat ? customLabelFormat(label) : label;
+      option.value = label;
       return option;
     });
   } else {

--- a/src/MultiDropdownInputWithSearch/MultiDropdownInputWithSearch.tsx
+++ b/src/MultiDropdownInputWithSearch/MultiDropdownInputWithSearch.tsx
@@ -211,9 +211,9 @@ const MultiDropdownInputWithSearch = <T,>({
         ignoreCase: true,
       })}
       isDisabled={isDisabled}
-      closeMenuOnSelect={isMulti ? false : true}
+      closeMenuOnSelect={!isMulti}
       isMulti={isMulti}
-      controlShouldRenderValue={isMulti ? false : true}
+      controlShouldRenderValue={!isMulti}
       backspaceRemovesValue={false}
       placeholder={label}
       hideSelectedOptions={false}

--- a/src/MultiDropdownInputWithSearch/MultiDropdownInputWithSearch.tsx
+++ b/src/MultiDropdownInputWithSearch/MultiDropdownInputWithSearch.tsx
@@ -47,10 +47,16 @@ const DropdownIndicator = ({
   );
 };
 
-function getOptionsWithLabels(options: any, labelKey?: string) {
+function getOptionsWithLabels(
+  options: any,
+  labelKey?: string,
+  customLabelFormat?: (value: string | Record<string, any>) => string
+) {
   if (labelKey) {
     return options.map((option: any) => {
-      option.label = option[labelKey];
+      option.label = customLabelFormat
+        ? customLabelFormat(option[labelKey])
+        : option[labelKey];
       option.value = option[labelKey];
       return option;
     });
@@ -149,16 +155,20 @@ const MultiDropdownInputWithSearch = <T,>({
   isDisabled,
   width = 50,
   selectLimit,
+  customLabelFormat,
+  isMulti = true,
 }: MultiDropdownInputWithSearchType<T>) => {
   const [interimValue, setInterimValue] = useState<T[] | undefined>(undefined);
 
   const option = useMemo(
-    () => getOptionsWithLabels(options, labelKey),
-    [options, labelKey]
+    () => getOptionsWithLabels(options, labelKey, customLabelFormat),
+    [options, labelKey, customLabelFormat]
   );
 
   const onMenuOpen = () => {
-    setInterimValue(value);
+    if (isMulti) {
+      setInterimValue(value);
+    }
   };
 
   const onMenuClose = () => {
@@ -178,6 +188,14 @@ const MultiDropdownInputWithSearch = <T,>({
     setInterimValue(selectedValues);
   };
 
+  const onSelectChange = (selectedValue: any) => {
+    if (!labelKey) {
+      selectedValue = selectedValue?.value;
+    }
+
+    onChange(selectedValue);
+  };
+
   const selectValue = interimValue ?? value ?? [];
 
   return (
@@ -187,22 +205,22 @@ const MultiDropdownInputWithSearch = <T,>({
       options={option}
       onMenuOpen={onMenuOpen}
       onMenuClose={onMenuClose}
-      onChange={onMultipleSelectChange}
+      onChange={isMulti ? onMultipleSelectChange : onSelectChange}
       filterOption={createFilter({
         ignoreAccents: false,
         ignoreCase: true,
       })}
       isDisabled={isDisabled}
-      closeMenuOnSelect={false}
-      isMulti={true}
-      controlShouldRenderValue={false}
+      closeMenuOnSelect={isMulti ? false : true}
+      isMulti={isMulti}
+      controlShouldRenderValue={isMulti ? false : true}
       backspaceRemovesValue={false}
       placeholder={label}
       hideSelectedOptions={false}
       isClearable={false}
       // @ts-expect-error unreachable type
       components={
-        selectLimit && selectValue?.length > selectLimit
+        isMulti && selectLimit && selectValue?.length > selectLimit
           ? { DropdownIndicator }
           : undefined
       }

--- a/src/MultiDropdownInputWithSearch/MultipleDropdownInputWithsearch.stories.js
+++ b/src/MultiDropdownInputWithSearch/MultipleDropdownInputWithsearch.stories.js
@@ -6,7 +6,11 @@ const Template = (args) => {
   const [state, setState] = useArgs();
 
   const onChange = (value) => {
-    setState({ value });
+    if (args.isMulti) {
+      setState({ value });
+    } else {
+      setState({ value: [value] });
+    }
   };
 
   return <MultiDropdownInputWithSearch {...args} onChange={onChange} />;
@@ -22,6 +26,7 @@ Default.args = {
   label: "Sites",
   width: 100,
   selectLimit: 2,
+  isMulti: true,
 };
 
 export const WithObjectOptions = Template.bind({});
@@ -34,6 +39,7 @@ WithObjectOptions.args = {
   label: "Sites",
   labelKey: "name",
   width: 100,
+  isMulti: true,
 };
 WithObjectOptions.storyName = "With object options";
 

--- a/src/types/MultiDropdownInputWithSearch/index.tsx
+++ b/src/types/MultiDropdownInputWithSearch/index.tsx
@@ -15,8 +15,8 @@ type MultiDropdownInputWithSearchType<T> = {
   isDisabled?: boolean;
   width?: number;
   selectLimit?: number;
-  customLabelFormat: (value: string | Record<string, any>) => string;
-  isMulti: true | undefined;
+  customLabelFormat?: (value: string | Record<string, any>) => string;
+  isMulti?: true | undefined;
 };
 
 export type MultiDropdownInputWithSearchHintType = {

--- a/src/types/MultiDropdownInputWithSearch/index.tsx
+++ b/src/types/MultiDropdownInputWithSearch/index.tsx
@@ -15,6 +15,8 @@ type MultiDropdownInputWithSearchType<T> = {
   isDisabled?: boolean;
   width?: number;
   selectLimit?: number;
+  customLabelFormat: (value: string | Record<string, any>) => string;
+  isMulti: true | undefined;
 };
 
 export type MultiDropdownInputWithSearchHintType = {


### PR DESCRIPTION
## Scope
- [x] Enhancement: backwards-compatible functionality added
- [ ] Bug-Fix / Patch: backwards-compatible bug fix / revision
- [ ] RFC: request for comments; discussion only

## Context
We want to remove DropdownWithSearch usage in 360, and since MultiDropdownWithSearch is close enough in functionality (and has some brand styling), we'll modify it be MultiDropdownWithSearch to accept single values using `isMulti` prop.

## Summary of Changes
![2022-03-01 20 19 24](https://user-images.githubusercontent.com/34279434/156276467-bece5b66-db56-40a1-9eaa-dd51166cc1aa.gif)



## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Pre-Merge Checklist
- [ ] Changelog entry? (Summary in `/changelog/<section>/<issue_number>.md`)
- [ ] Linked to [Jira issue](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) ?
- [ ] Labels tagged?