### PR TITLE
Fix Panel loaded content height

### DIFF
--- a/src/Panel/Panel.module.scss
+++ b/src/Panel/Panel.module.scss
@@ -25,6 +25,10 @@
     margin-left: 0px;
     margin-right: 12px;
   }
+
+  :global(.loadedContent) {
+    height: 100%;
+  }
 }
 
 .clickable {


### PR DESCRIPTION
## Scope
- [ ] Enhancement: backwards-compatible functionality added
- [x] Bug-Fix / Patch: backwards-compatible bug fix / revision
- [ ] RFC: request for comments; discussion only

## Context
Panels use `ReactLoader` when the `loaded` prop is used, which shows/hides the `.loadedContent` div. That div has 0 height, which makes components that rely on container height (e.g. the `Autosizer` that controls `DatatableGrid`) also have 0 height and not appear. The fix to this is to set the `.loadedContent` height to 100%, which is what we've been doing locally (e.g. `ThirdPartyLabImport.scss`). Since this is usually the wanted behaviour (loaded content taking up all the space), put it in styling by default.

## Summary of Changes
- Panels that have loaders may not display Datatables properly because of `.loadedContent` being 0 height. Fix this.

| Before | After |
| ------ | ----- |
|![Screen Shot 2022-03-02 at 10 23 16 AM](https://user-images.githubusercontent.com/34279434/156393020-368bfa50-e114-4a25-a284-27b7a60f2437.png)|![Screen Shot 2022-03-02 at 10 23 59 AM](https://user-images.githubusercontent.com/34279434/156393076-2cc3fc5e-7d16-457e-9db8-2ac0c6bd1a2c.png)|

## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Pre-Merge Checklist
- [ ] Changelog entry? (Summary in `/changelog/<section>/<issue_number>.md`)
- [ ] Linked to [Jira issue](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) ?
- [ ] Labels tagged?