### PR TITLE
Remove back to hubs button and change homeTabText to validere logo

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,7 @@
 const config = {
   VALIDERE_ICON_URL: "https://validere.com/wp-content/uploads/logo_icon.png",
+  VALIDERE_LOGO_URL:
+    "https://validere.com/wp-content/uploads/logo_white_text.png",
   DATE_FORMAT: "YYYY-MM-DD",
   TIME_FORMAT: "HH:mm:ss",
   DATETIME_FORMAT: "YYYY-MM-DD HH:mm:ss z",

--- a/src/Sidebar/Sidebar.module.scss
+++ b/src/Sidebar/Sidebar.module.scss
@@ -83,8 +83,8 @@ $tabContainerPadding: 8px 20px 8px 10px;
   }
 
   &--home {
-    text-transform: uppercase;
-    color: var(--colour-white);
+    overflow: hidden;
+    text-overflow: clip;
     cursor: default;
   }
 }
@@ -125,6 +125,11 @@ $tabContainerPadding: 8px 20px 8px 10px;
   width: 22px;
   height: 19px;
   margin-right: 15px;
+}
+
+.validereLogo {
+  width: 100px;
+  height: 15px;
 }
 
 .backIcon {

--- a/src/Sidebar/Sidebar.test.js
+++ b/src/Sidebar/Sidebar.test.js
@@ -67,7 +67,6 @@ describe("Sidebar tests", () => {
     const isPinned = true;
     const onPinClick = jest.fn();
     const onProfileClick = jest.fn();
-    const onBackClick = jest.fn();
 
     const { container, getByRole, getAllByRole, queryAllByRole } = render(
       <Sidebar
@@ -80,13 +79,10 @@ describe("Sidebar tests", () => {
         onPinClick={onPinClick}
         version={version}
         onProfileClick={onProfileClick}
-        onBackClick={onBackClick}
       />
     );
 
-    const backToHubsButton = getByRole("button", { name: /backtohub/i });
     const settingButton = getByRole("button", { name: /settings/i });
-    userEvent.click(backToHubsButton);
 
     expect(queryAllByRole("menuItem")[0]).toBeFalsy();
     expect(queryAllByRole("menuItem")[1]).toBeFalsy();
@@ -104,7 +100,6 @@ describe("Sidebar tests", () => {
 
     expect(queryAllByRole("menuItem")[0]).toBeFalsy();
     expect(queryAllByRole("menuItem")[1]).toBeFalsy();
-    expect(onBackClick).toHaveBeenCalledTimes(1);
   });
 
   test("Should render sidebar features even though sidebar not pinned", () => {
@@ -116,7 +111,6 @@ describe("Sidebar tests", () => {
     const onSignOut = jest.fn();
     const onPinClick = jest.fn();
     const onProfileClick = jest.fn();
-    const onBackClick = jest.fn();
 
     const { getAllByRole } = render(
       <Sidebar
@@ -129,18 +123,16 @@ describe("Sidebar tests", () => {
         onPinClick={onPinClick}
         version={version}
         onProfileClick={onProfileClick}
-        onBackClick={onBackClick}
-        homeTabText="Operations"
       />
     );
 
     const tabTitles = getAllByRole("tabTitle");
-    expect(tabTitles[0].textContent).toEqual("Back to hubs");
-    expect(tabTitles[1].textContent).toEqual("Operations");
-    expect(tabTitles[2].textContent).toEqual("Workflow");
-    expect(tabTitles[3].textContent).toEqual("Instruments");
-    expect(tabTitles[4].textContent).toEqual("Samples");
-    expect(tabTitles[5].textContent).toEqual("Lock Sidebar");
+    expect(tabTitles.map((reactNode) => reactNode.textContent)).toEqual([
+      "Workflow",
+      "Instruments",
+      "Samples",
+      "Lock Sidebar",
+    ]);
   });
 
   test("Should render Collapse sidebar text when Sidebar is pinned", () => {
@@ -152,7 +144,6 @@ describe("Sidebar tests", () => {
     const onSignOut = jest.fn();
     const onPinClick = jest.fn();
     const onProfileClick = jest.fn();
-    const onBackClick = jest.fn();
 
     const { getAllByRole } = render(
       <Sidebar
@@ -165,19 +156,17 @@ describe("Sidebar tests", () => {
         onPinClick={onPinClick}
         version={version}
         onProfileClick={onProfileClick}
-        onBackClick={onBackClick}
-        homeTabText="Operations"
         isPinned={true}
       />
     );
 
     const tabTitles = getAllByRole("tabTitle");
-    expect(tabTitles[0].textContent).toEqual("Back to hubs");
-    expect(tabTitles[1].textContent).toEqual("Operations");
-    expect(tabTitles[2].textContent).toEqual("Workflow");
-    expect(tabTitles[3].textContent).toEqual("Instruments");
-    expect(tabTitles[4].textContent).toEqual("Samples");
-    expect(tabTitles[5].textContent).toEqual("Collapse Sidebar");
+    expect(tabTitles.map((reactNode) => reactNode.textContent)).toEqual([
+      "Workflow",
+      "Instruments",
+      "Samples",
+      "Collapse Sidebar",
+    ]);
   });
 
   test("Should expand and collapse dropdown ", () => {

--- a/src/Sidebar/Sidebar.tsx
+++ b/src/Sidebar/Sidebar.tsx
@@ -25,8 +25,6 @@ const Sidebar = ({
   isPinned = false,
   onPinClick,
   isExpanded = false,
-  homeTabText,
-  onBackClick,
   onProfileClick,
 }: SidebarType) => {
   const [openListTab, setOpenListTab] = useState(activeTab);
@@ -55,35 +53,19 @@ const Sidebar = ({
         width: isSidebarExpanded ? SIDEBAR_WIDTH : MINI_SIDEBAR_WIDTH,
       }}
     >
-      {onBackClick && (
-        <button
-          className={cx("tabContainer", "tabContainer--back", {
-            "tabContainer--back--collapse": !isSidebarExpanded,
-          })}
-          onClick={onBackClick}
-          aria-label="backtohub"
-        >
-          <FontAwesome className={cx("backIcon")} name="arrow-circle-o-left" />
+      <div className={cx("tabContainer", "tabContainer--home")}>
+        <img
+          className={cx("validereIcon")}
+          src={config.VALIDERE_ICON_URL}
+          alt="Validere"
+        />
 
-          <SidebarTabText isVisible={isSidebarExpanded}>
-            Back to hubs
-          </SidebarTabText>
-        </button>
-      )}
-
-      {homeTabText && (
-        <div className={cx("tabContainer", "tabContainer--home")}>
-          <img
-            className={cx("validereIcon")}
-            src={config.VALIDERE_ICON_URL}
-            alt="Validere"
-          />
-
-          <SidebarTabText isVisible={isSidebarExpanded}>
-            {homeTabText}
-          </SidebarTabText>
-        </div>
-      )}
+        <img
+          className={cx("validereLogo")}
+          src={config.VALIDERE_LOGO_URL}
+          alt="Validere"
+        />
+      </div>
 
       <div
         className={cx("tabsWrapper", {

--- a/src/types/Sidebar/index.tsx
+++ b/src/types/Sidebar/index.tsx
@@ -29,10 +29,6 @@ export type SidebarType = TabDetail & {
   onSignOut: React.MouseEventHandler<HTMLDivElement>;
   /**  Boolean function determining is sidebar is currently expanded */
   isExpanded: boolean;
-  /** Text describing the current web app */
-  homeTabText: string;
-  /** The function called when the back link is clicked */
-  onBackClick: React.MouseEventHandler<HTMLButtonElement>;
   /** The function called when View profile is clicked */
   onProfileClick: React.MouseEventHandler<HTMLDivElement>;
 };


### PR DESCRIPTION
## Scope
- [ ] Enhancement: backwards-compatible functionality added
- [ ] Bug-Fix / Patch: backwards-compatible bug fix / revision
- [ ] RFC: request for comments; discussion only

## Context
The back button isn't wanted anymore, neither is the "OPERATIONS" text on the sidebar. Remove these and replace the "OPERATIONS" text with the Validere logo.

## Summary of Changes
- remove back button
- remove operations text
- add back in the Validere Logo

| Before | After |
| ------ | ----- |
|![Screen Shot 2022-03-15 at 8 35 45 AM](https://user-images.githubusercontent.com/34279434/158379319-33acfe3f-fc74-47a4-9471-04d4129095f0.png)|![Screen Shot 2022-03-15 at 8 34 21 AM](https://user-images.githubusercontent.com/34279434/158379294-70f44600-8214-4a82-892a-7d7fdccc66ff.png)|

## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Pre-Merge Checklist
- [ ] Changelog entry? (Summary in `/changelog/<section>/<issue_number>.md`)
- [ ] Linked to [Jira issue](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) ?
- [ ] Labels tagged?